### PR TITLE
Add Notebooks For All usability test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Materials for and results from Jupyter user surveys.
 - [December, 2015 Notebook UX survey results](surveys/2015-12-notebook-ux)
 - [August, 2018 JupyterLab UX testing results](surveys/2018-09-jupytercon-2018)
 - [December, 2020 Jupyter survey](surveys/2020-12-jupyter-survey)
+- [August, 2022 Notebooks For All accessibility usability testing](surveys/2022-08-notebooks-for-all/)
 
 IPython user surveys
 ====================

--- a/surveys/2022-08-notebooks-for-all/README.MD
+++ b/surveys/2022-08-notebooks-for-all/README.MD
@@ -1,0 +1,20 @@
+# Notebooks For All
+
+This folder links to results from the 2022–2023 accessibility-focused usability tests on notebooks converted to HTML via [nbconvert](https://github.com/jupyter/nbconvert). This includes:
+- 2022 August's test 1 [Results: Structure & Navigation in Rendered Notebooks](https://github.com/Iota-School/notebooks-for-all/blob/main/user-tests/1-navigation/results.md). This document aggregates results describing the ways disabled participants navigated the notebook structure. It was designed to answer the question "How do users navigate and access different levels of structure within HTML outputs of Jupyter notebooks?"
+- 2022 November-2023 January's test 2 [Results: Content Access in Rendered Notebooks](https://github.com/Iota-School/notebooks-for-all/blob/main/user-tests/2-content/results.md). This document aggregates results of how accessible and comfortable working with different content types was for disabled participants. It was designed to answer the question " How are users able to access a range of commonly used content types within HTML outputs of Jupyter notebooks?"
+- The [full list of user testing results and resources](https://github.com/Iota-School/notebooks-for-all/tree/main/user-tests#readme). This includes full test scripts and notebooks used per test.
+
+Tests were conducted synchronously in small group settings on Zoom. All tests included one participant, one facilitator/meeting host, and one note taker. Participants were recruited via team member connections to disability and accessibility communities outside of Project Jupyter.
+
+## Background
+
+As a part of ongoing efforts to understand the accessibility status of Jupyter projects and tools, Notebooks For All was made to evaluate and identify accessibility fixes for the Jupyter notebook-driven tutorial and documentation processes like those used by some public resources from the Space Telescope Science Institute. Because HTML converted notebooks as documentation is not an uncommon process in the wider community, this work and the issues raised apply to other projects and the default nbconvert templates more broadly. The full project proposal will be available on [jupyter/accessibility](https://github.com/jupyter/accessibility).
+
+The team initially connected over Jupyter accessibility meetings on the public [Jupyter Community Calendar](https://docs.jupyter.org/en/latest/community/content-community.html#jupyter-community-meetings).
+
+## Credits
+
+The Notebooks For All team includes [Erik Tollerud](https://github.com/eteq/) (Space Telescope Science Institute), [Isabela Presedo-Floyd](https://github.com/isabela-pf/) (Quansight Labs), [Jenn Kotler](https://github.com/jenneh)(Space Telescope Science Institute), [Patrick Smyth](https://github.com/smythp) (Iota School), and [Tony Fast](https://github.com/tonyfast/).
+
+Usability testing was led by Jenn Kotler and Isabela Presedo-Floyd.


### PR DESCRIPTION
I'm excited to bring some accessibility efforts to the Jupyter surveys repo! 

This PR:
- Creates a directory under `surveys` for the Notebooks For All project (accessibility testing and fixes for HTML converted notebook files and nbconvert)
- Adds a project readme that provides information about the tests. It also links to the results and resources.
- Adds the project to the root repo readme under `Jupyter user surveys`

Please let me know if you have any questions. Thanks in advance for review! 🌻 

cc: @eteq, @jenneh, @smythp, and @tonyfast because your names are mentioned as the project team.