### PR TITLE
Add 2023 JupyterLab accessibility test results

### DIFF
--- a/surveys/2023-05-jupyterlab-accessibility/README.MD
+++ b/surveys/2023-05-jupyterlab-accessibility/README.MD
@@ -1,0 +1,21 @@
+# JupyterLab Accessibility Overview
+
+This folder links to results from the May 2023 accessibility-focused usability study on JupyterLab 3.6.1 (hosted via JupyterHub). This includes:
+-  [Results: JupyterLab Accessibility Overview](https://github.com/Quansight-Labs/JupyterLab-user-testing/blob/main/results/user-testing-results.md) in the [testing repository](https://github.com/Quansight-Labs/JupyterLab-user-testing/). This document describes the ways participants completed common tasks in JupyterLab with assistive tech, points out issues, and identifies opportunities for improvement.
+- The [test script](https://github.com/Quansight-Labs/JupyterLab-user-testing/blob/main/results/user-testing-script.md) including all tasks requested and questions asked. This document was used during every session and may help in interpreting the results.
+
+Tests were conducted synchronously in small group settings on Google Meet. All tests included one participant, one facilitator/meeting host, and possibly a note taker. 
+
+Participants were recruited via outreach on Jupyter channels like [the Jupyter Discourse forum](https://discourse.jupyter.org/t/participate-in-a-jupyterlab-accessibility-study/18786), [the Jupyter mailing list](https://groups.google.com/g/jupyter/c/HnvFbeeVtD0), and [team member Twitter accounts](https://twitter.com/isabelapf2/status/1648712695229878276). This was an open call with a few screening questions to make sure we could pay participants in their respective region.
+
+## Background
+
+This study was designed as a baseline for usability testing of accessibility in JupyterLab. It is meant to focus on tasks required in nearly every user workflow (like opening files, reading a notebook, editing a notebook, changing settings, etc.) and tasks designed to have participants navigate through different major regions in JupyterLab (moving from the menu bar to side bar to main content area, etc.). Because we did not have prior open accessible user testing feedback for JupyterLab to reference, the primary goal was to gather a range of information from a range of assistive tech users over as full of a range of JupyterLab as we could within the time constraints.
+
+As a part of ongoing efforts to increase JupyterLab's accessibility, this work was funded by a [Chan Zuckerberg Initiative Essential Open Source Software for Science grant](https://chanzuckerberg.com/eoss/proposals/inclusive-and-accessible-scientific-computing-in-the-jupyter-ecosystem/). The [full grant proposal can be found on the jupyter/accessibility repository](https://github.com/jupyter/accessibility/blob/da6db43da092255c205ce1603d0d10b1f51c131b/docs/funding/Inclusive_and_Accessible_Scientific_Computing_in_Jupyter_Ecosystem_SUBMITTED_PROPOSAL.pdf).
+
+## Credits
+
+The team includes [Gabriel Fouasnon](https://github.com/gabalafou/), [Isabela Presedo-Floyd](https://github.com/isabela-pf/), [Stephannie Jimenez Gacha](https://github.com/steff456), and [Tania Allard](https://github.com/trallard) all at [Quansight Labs](https://labs.quansight.org/).
+
+Usability testing was led by Isabela Presedo-Floyd.


### PR DESCRIPTION
Finally I can share some JupyterLab user testing work. It feels like a long time coming.

This PR:
- Creates a directory under `surveys` for the 2023 JupyterLab accessibility testing
- Adds a project readme that provides information about the tests. It also links to the results and resources.

It does *not yet* add the project to the root repo readme under `Jupyter user surveys` because I am trying to avoid a merge conflict with #26. If there's a better way to handle this, please let me know.

Please let me know if you have any questions. Thanks in advance for any review! 🌻 

cc: @gabalafou, @trallard, @steff456, because your names are mentioned in the credits!